### PR TITLE
Inskcape export arg  correction (+ .gitignore update)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/*/??.svg
 build/*/??.png
 build/png-*
 build/xplanet
+build/svg*/*.svg

--- a/scripts/build.pl
+++ b/scripts/build.pl
@@ -812,7 +812,7 @@ sub svg2png {
     # is $out older than $in?
 
     if (!-e $out || -M $out > -M $in) {
-		my $cmd = "inkscape -z -e ".$out." -w ".$w." -h ".$h." ".$in;
+		my $cmd = "inkscape -z -o ".$out." -w ".$w." -h ".$h." ".$in;
 		if ($h <= 128) {
 			$cmd .= " && convert ".$out." -unsharp 0x1 ".$out;
 		}


### PR DESCRIPTION
Latest versions of Inkscape use '-o' instead of '-e' to define export file path.